### PR TITLE
Add a Python venv to compile properly on Apple Silicon

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ python-dateutil==2.8.2
 pywin32-ctypes==0.2.2
 PyYAML==6.0.1
 six==1.16.0
+tk==8.6.14

--- a/run.sh
+++ b/run.sh
@@ -1,2 +1,4 @@
-pip3 install -r requirements.txt
-pyinstaller app.py
+python3 -m venv venv
+source venv/bin/activate
+pip3 install -r requirements.txt --break-system-packages
+python3 -m PyInstaller app.py


### PR DESCRIPTION
Created a Virtual Environment to make sure tkinter works properly on M1 (and above) Macs.